### PR TITLE
Fix pushing drafts

### DIFF
--- a/lib/gerrit/command/push.rb
+++ b/lib/gerrit/command/push.rb
@@ -158,7 +158,7 @@ module Gerrit::Command
                 .modify(:downcase)
                 .read_string
 
-      draft == 'y' ? 'draft' : 'publish'
+      draft == 'y' ? 'drafts' : 'publish'
     end
 
     def ask_topic


### PR DESCRIPTION
Pushing a draft seems to push to `refs/draft/master` which results in
the following error:

> ! [remote rejected] HEAD -> refs/draft/master (prohibited by Gerrit)

Instead, it should push to `refs/drafts/master`.

Fixes #2
