### PR TITLE
Add warn_reviewer_count configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ push_remote: gerrit
 # the memberships of all that user's groups in order to find potential matches.
 user_search_groups:
   - 'Registered Users'
+
+# Require command-line consent to push a review to this many reviewers:
+warn_reviewer_count: 4
 ```
 
 ## Usage

--- a/lib/gerrit/command/push.rb
+++ b/lib/gerrit/command/push.rb
@@ -23,7 +23,7 @@ module Gerrit::Command
 
       reviewers = extract_reviewers(reviewer_args)
 
-      if reviewers.size > 3
+      if reviewers.size >= @config.fetch(:warn_reviewer_count, 4)
         ui.newline
         ui.info("You are adding #{reviewers.size} people as reviewers for this change")
 

--- a/lib/gerrit/version.rb
+++ b/lib/gerrit/version.rb
@@ -1,4 +1,4 @@
 # Defines the gem version.
 module Gerrit
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
I don't know if you appreciate how much I like not having to interact
with my `gerrit push` command :). This adds an option so I can set a
higher count of people that I'm okay with spamming, in the (very real)
case that I have a team size right on the threshold that the gem sets.
