### PR TITLE
Fix `gerrit setup [project]` to actually use project argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gerrit Changelog
 
+## master (unreleased)
+
+* Fix `gerrit setup [project]` invocation not naming git remotes according to
+  the argument.
+
 ## 0.11.0
 
 * Improve output of `gerrit clone` command to show progress

--- a/lib/gerrit/command/setup.rb
+++ b/lib/gerrit/command/setup.rb
@@ -77,8 +77,8 @@ module Gerrit::Command
     # Allow a project name to be explicitly specified, otherwise just use the
     # repo root directory name.
     def project_name
-      if arguments[2]
-        arguments[2]
+      if arguments[1]
+        arguments[1]
       else
         File.basename(repo.root)
       end


### PR DESCRIPTION
Due to a typo in this function, `gerrit setup [project]` was using the
directory name instead of the given argument.
